### PR TITLE
Temperature Formatting Options

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,3 +24,5 @@ var reloadHour = 4;	// time at which to reload the entire page. Helps keep thing
 var weatherUnit = "fc"; //c for celsius, f for farenheit, cf for celsius (farenheit), fc for farenheit (celsius)
 var tempRound = false;	//rounds all temperatures to whole numbers (so today and forecast match)
 
+var twelveHour = false;	//if true, time is displayed as 12-hour rather than 24-hour
+var twelveHourAMPM = true;	//if true, 'am' or 'pm' is appended to the time. Probably doesn't make sense unless twelveHour is also true.

--- a/config.js
+++ b/config.js
@@ -21,3 +21,6 @@ var forecastFrequency = 3600000;	// every 3600 seconds (= 1 hour)
 
 var reloadHour = 4;	// time at which to reload the entire page. Helps keep things fresh (Chrome tends to time out the websockets). 24 hour format (0 = midnight, 23 = 11 PM)
 
+var weatherUnit = "fc"; //c for celsius, f for farenheit, cf for celsius (farenheit), fc for farenheit (celsius)
+var tempRound = false;	//rounds all temperatures to whole numbers (so today and forecast match)
+

--- a/css/style.css
+++ b/css/style.css
@@ -79,7 +79,7 @@ widget {
 }
 
 .clock{
-	width: 100px;
+	width: 120px;
 	text-align: center;
 	font-weight: bold;
 	margin: 0 auto;

--- a/css/style.css
+++ b/css/style.css
@@ -119,15 +119,15 @@ widget {
 	position: absolute; 
 	bottom: 0; 
 	left: 0; 
-	width: 500px; 
+	width: 50%; 
 	height: 100px;
 }
 
 .weather_forecast{
 	position: absolute; 
 	bottom: 0; 
-	left: 500px; 
-	width: 500px; 
+	left: 50%; 
+	width: 50%; 
 	height: 100px; 
 	border-left: solid 1px rgba(255, 255, 255, 0.3);
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -17,7 +17,7 @@ function Start()
 function StartTime() {
 	var today = new Date();
 
-	$("div.clock").html(today.getHours() + ":" + ToDoubleDigits(today.getMinutes()));
+	$("div.clock").html((twelveHour == true ? (today.getHours() % 12 || 12) : today.getHours())+ ":" + ToDoubleDigits(today.getMinutes()) + (twelveHourAMPM == true ? (today.getHours() >= 12 ? 'pm' : 'am') : ""));	// + " " + (today.getHours() >= 12 ? 'pm' : 'am')
 	$("div.date").html(today.toDateString());
 	
 	if (today.getHours() == reloadHour && today.getMinutes() == 0 && secondsSinceLoad > 600) {	// The extra checks besides reloadHour are to make sure we don't reload every second when we hit reloadHour

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -239,8 +239,8 @@ function GetWeatherConditions()
 		// The weather service sends back a lot of data, but we'll only use some
 		$("#observation_icon").attr("src", "weather/" + data.current_observation.icon + ".png");
 		$("#observation_weather").html(ParseWeatherConditions(data.current_observation.weather));
-		$("#observation_temperature").html(data.current_observation.temperature_string);
-		$("#observation_feelslike").html("feels like: " + data.current_observation.feelslike_string);
+		$("#observation_temperature").html(formatTemperature(data.current_observation.temp_c,data.current_observation.temp_f));
+		$("#observation_feelslike").html("feels like: " + formatTemperature(data.current_observation.feelslike_c,data.current_observation.feelslike_f));
 		$("#observation_time").html(data.current_observation.observation_time);
 	}).fail( function(jqXHR, data) { 
 		Log("Error getting weather: " + data, 1);
@@ -266,15 +266,15 @@ function GetWeatherForecast()
 		$("#forecast_title", "#weather_today").html(data.forecast.simpleforecast.forecastday[0].date.weekday);
 		$("#forecast_icon", "#weather_today").attr("src", "weather/" + data.forecast.simpleforecast.forecastday[0].icon + ".png");
 		$("#forecast_conditions", "#weather_today").html(ParseWeatherConditions(data.forecast.simpleforecast.forecastday[0].conditions));
-		$("#forecast_high", "#weather_today").html(data.forecast.simpleforecast.forecastday[0].high.fahrenheit + "F (" + data.forecast.simpleforecast.forecastday[0].high.celsius + "C)");
-		$("#forecast_low", "#weather_today").html(data.forecast.simpleforecast.forecastday[0].low.fahrenheit + "F (" + data.forecast.simpleforecast.forecastday[0].low.celsius + "C)");
-		
+		$("#forecast_high", "#weather_today").html(formatTemperature(data.forecast.simpleforecast.forecastday[0].high.celsius,data.forecast.simpleforecast.forecastday[0].high.fahrenheit));
+		$("#forecast_low", "#weather_today").html(formatTemperature(data.forecast.simpleforecast.forecastday[0].low.celsius,data.forecast.simpleforecast.forecastday[0].low.fahrenheit));
+
 		$("#forecast_title", "#weather_tomorrow").html(data.forecast.simpleforecast.forecastday[1].date.weekday);
 		$("#forecast_icon", "#weather_tomorrow").attr("src", "weather/" + data.forecast.simpleforecast.forecastday[1].icon + ".png");
 		$("#forecast_conditions", "#weather_tomorrow").html(ParseWeatherConditions(data.forecast.simpleforecast.forecastday[1].conditions));
-		$("#forecast_high", "#weather_tomorrow").html(data.forecast.simpleforecast.forecastday[1].high.fahrenheit + "F (" + data.forecast.simpleforecast.forecastday[1].high.celsius + "C)");
-		$("#forecast_low", "#weather_tomorrow").html(data.forecast.simpleforecast.forecastday[1].low.fahrenheit + "F (" + data.forecast.simpleforecast.forecastday[1].low.celsius + "C)");
-		
+		$("#forecast_high", "#weather_tomorrow").html(formatTemperature(data.forecast.simpleforecast.forecastday[1].high.celsius,data.forecast.simpleforecast.forecastday[1].high.fahrenheit));
+		$("#forecast_low", "#weather_tomorrow").html(formatTemperature(data.forecast.simpleforecast.forecastday[1].low.celsius,data.forecast.simpleforecast.forecastday[1].low.fahrenheit));
+
 		$("#forecast_time").html("Forecast Time: " + data.forecast.txt_forecast.date);
 		
 		// After 5 PM: show tomorrow's forecast. Before 5 PM: show today's.
@@ -384,3 +384,23 @@ String.prototype.format = function() {
     }
     return s;
 };
+
+function formatTemperature(c, f) {
+	tempC_suffix = "C";
+	tempF_suffix = "F";
+
+	if (tempRound == true) {
+    	c = Math.round(c).toString();
+    	f = Math.round(f).toString();
+	}	
+
+	if (weatherUnit == "c"){
+		return (c + tempC_suffix);
+	} else if (weatherUnit == "f") {
+		return (f + tempF_suffix);
+	} else if (weatherUnit == "cf") {
+		return (c + tempC_suffix + " (" + f + tempF_suffix + ")");
+	} else {
+		return (f + tempF_suffix + " (" + c + tempC_suffix + ")");
+	}
+}


### PR DESCRIPTION
Added options to format temperature to either Celsius, Fahrenheit, Celsius (Fahrenheit) or Fahrenheit (Celsius). I see there was an earlier pull-request and discussion on this in the non-advanced repo, this replicates the functionality of that pull-request plus the changes requested (displaying both).

Also added option to round temperatures to whole numbers for consistency between current and forecast temperatures.

Please let me know if there's anything I should change!
